### PR TITLE
feat: Type hints in docs

### DIFF
--- a/app/my_class.py
+++ b/app/my_class.py
@@ -1,6 +1,7 @@
 """
 This is the docstring for the module.
 """
+from typing import Any, Optional, Union
 
 
 class MyClass:
@@ -22,6 +23,32 @@ class MyClass:
         """
         Check if it's *ok*.
 
-        :return: `True` if it's ok, `False` oherwise.
+        :return: `True` if it's ok, `False` otherwise.
         """
         return self.a > 0 and self.b.lower() == 'ok'
+
+    def with_typehints_1(self, name: str, x: Optional[str] = None, i: Union[float, int] = 0):
+        """
+        Method with type hints to see how they look in the documentation.
+
+        The return type is type is not specified in the method signature or in the `:return:` portion of the
+        docstring.
+
+        :param name: The name of something.
+        :param x: Mysterious argument.
+        :param i: A Number for the sake of it. Uses the `Union` syntax.
+        """
+        pass
+
+    def with_typehints_2(self, no_th, a: Any, i: float | int) -> list[tuple[int, str, Any]]:
+        """
+        Another method with type hints to see how it looks in documentation.
+
+        Return type is complicated.
+
+        :param no_th: Parameter with no type hint.
+        :param a: Can be anything.
+        :param i: A Number for the sake of it. Uses the `|` syntax.
+        :return: A list of stuff.
+        """
+        return []

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -141,6 +141,9 @@ sphinx==4.4.0
     # via
     #   -r requirements.txt
     #   myst-parser
+    #   sphinx-autodoc-typehints
+sphinx-autodoc-typehints==1.17.0
+    # via -r requirements.txt
 sphinxcontrib-applehelp==1.0.2
     # via
     #   -r requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ templates_path = ['docs/_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,8 @@ author = 'Joao Coelho'
 # ones.
 extensions = [
     'myst_parser',
-    'sphinx.ext.autodoc'
+    'sphinx.ext.autodoc',
+    'sphinx_autodoc_typehints',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 livereload
 myst-parser
 sphinx
+sphinx-autodoc-typehints

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,9 @@ sphinx==4.4.0
     # via
     #   -r requirements.in
     #   myst-parser
+    #   sphinx-autodoc-typehints
+sphinx-autodoc-typehints==1.17.0
+    # via -r requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-devhelp==1.0.2

--- a/tests/test_my_class.py
+++ b/tests/test_my_class.py
@@ -1,6 +1,8 @@
 """
 Docstring for the test module.
 """
+import pytest
+
 from my_class import MyClass
 
 
@@ -12,6 +14,17 @@ def _is_ok(my_class: MyClass) -> bool:
     :param my_class: An instance of `MyClass`.
     """
     return my_class.is_ok()
+
+
+@pytest.fixture
+def some_fixture(request):
+    """
+    A pytest fixture.
+
+    :param request: `pytest`'s `request` object.
+    :return: Nothing
+    """
+    pass
 
 
 def test_something():
@@ -38,3 +51,36 @@ class TestMyClass:
         Tests that it's not ok.
         """
         assert MyClass(0, 'ok').is_ok() is False
+
+
+class TestAnother:
+    """
+    Another class with tests.
+    """
+
+    def test_using_fixture(self, some_fixture):
+        """
+        This test case uses a `pytest` fixture.
+        """
+        pass
+
+    @pytest.mark.parametrize('color', ['red', 'green'])
+    def test_parametrize(self, color):
+        """
+        Using `pytest`'s `parametrize`, which runs the test case multiple times with different parameter values.
+        """
+        pass
+
+    @pytest.mark.parametrize('color', ['yellow', 'blue'])
+    def test_fixture_and_parameterize(self, some_fixture, color):
+        """
+        Using both a `pytest` fixture and `parametrized`.
+        """
+        pass
+
+    @pytest.mark.pri1
+    def test_mark(self):
+        """
+        Test case with a `pytest` `mark`.
+        """
+        pass


### PR DESCRIPTION
Added `sphinx-autodoc-typehints` to better control how type hints are displayed in documentation.

Added more docstrings to see how they appear in documentation.